### PR TITLE
Disable stack shrinking by default

### DIFF
--- a/src/runtime/runtime1.go
+++ b/src/runtime/runtime1.go
@@ -381,6 +381,11 @@ func parsedebugvars() {
 		debug.madvdontneed = 1
 	}
 
+	// Beep beep: disable stack shrinking, possibly to fix:
+	// https://linear.app/beeper/issue/BLEEP-25986#comment-99e33468
+	// https://github.com/golang/go/issues/64781
+	debug.gcshrinkstackoff = 1
+
 	godebug := gogetenv("GODEBUG")
 
 	p := new(string)


### PR DESCRIPTION
This is an attempt to fix a Android crash based on a loosely related issue on the Go GitHub. Since we cannot reproduce the crash this is a best effort guess.

Note: we don't currently use this Go to build Android so that will need doing too.